### PR TITLE
OpenSSL support for OSX 10.11+

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -123,6 +123,10 @@ android/armeabi-v7a:
 osx:
 	ADDON_INCLUDES_EXCLUDE = libs/libwebsockets/include/win32port
 	ADDON_INCLUDES_EXCLUDE += libs/libwebsockets/include/win32port/win32helpers
+	# OpenSSL support for OSX 10.11+
+	ADDON_INCLUDES += ../../../libs/openssl/include
+	ADDON_LIBS += ../../../libs/openssl/lib/osx/libcrypto.a
+    ADDON_LIBS += ../../../libs/openssl/lib/osx/libssl.a
 
 ios:
 	ADDON_INCLUDES_EXCLUDE = libs/libwebsockets/include/win32port/.*


### PR DESCRIPTION
Note: Doesn’t break compilation against SDKs below 10.11